### PR TITLE
Update images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- Update CSI images to align with upstream.
+  - aws-ebs-csi-driver v0.8.1
+  - csi-provisioner v2.1.0
+  - csi-attacher v3.1.0
+  - csi-snapshotter v3.0.3
+  - csi-resizer v1.1.0
+  - livenessprobe v2.2.0
+  - csi-node-driver-registrar v2.1.0
+
 ## [1.1.0] - 2020-12-17
 
 ## [1.0.0] - 2020-12-02

--- a/helm/aws-ebs-csi-driver-app/Chart.yaml
+++ b/helm/aws-ebs-csi-driver-app/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
-appVersion: "0.8.0"
+appVersion: "0.8.1"
 name: aws-ebs-csi-driver-app
 description: A Helm chart for AWS EBS CSI Driver
 version: [[ .Version ]]
 namespace: kube-system
-kubeVersion: ">=1.13.0-0"
+kubeVersion: ">=1.14.0-0"
 home: https://github.com/giantswarm/aws-ebs-csi-driver-app
 sources:
   - https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v[[ .Version ]]/README.md

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -8,28 +8,28 @@ replicaCount: 1
 
 image:
   repository: quay.io/giantswarm/aws-ebs-csi-driver
-  tag: "v0.8.0"
+  tag: "v0.8.1"
   pullPolicy: IfNotPresent
 
 sidecars:
   provisionerImage:
     repository: quay.io/giantswarm/csi-provisioner
-    tag: "v2.0.4"
+    tag: "v2.1.0"
   attacherImage:
     repository: quay.io/giantswarm/csi-attacher
-    tag: "v3.0.2"
+    tag: "v3.1.0"
   snapshotterImage:
     repository: quay.io/giantswarm/csi-snapshotter
-    tag: "v3.0.2"
+    tag: "v3.0.3"
   livenessProbeImage:
     repository: quay.io/giantswarm/livenessprobe
-    tag: "v2.1.0"
+    tag: "v2.2.0"
   resizerImage:
     repository: quay.io/giantswarm/csi-resizer
-    tag: "v1.0.1"
+    tag: "v1.1.0"
   nodeDriverRegistrarImage:
     repository: quay.io/giantswarm/csi-node-driver-registrar
-    tag: "v2.0.1"
+    tag: "v2.1.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
No critical patches, mostly minor tweaks and fixes (logging, leader election health check, etc.) and deprecated flags (metrics-address).

**provisioner**
https://github.com/kubernetes-csi/external-provisioner/blob/master/CHANGELOG/CHANGELOG-2.1.md

**attacher**
https://github.com/kubernetes-csi/external-attacher/blob/release-3.1/CHANGELOG/CHANGELOG-3.1.md

**snapshotter**
https://github.com/kubernetes-csi/external-snapshotter/blob/v3.0.3/CHANGELOG/CHANGELOG-3.0.md

**resizer**
https://github.com/kubernetes-csi/external-resizer/blob/release-1.1/CHANGELOG-1.1.md

**node-registrar**
https://github.com/kubernetes-csi/node-driver-registrar/blob/master/CHANGELOG/CHANGELOG-2.1.md

**livenessprobe**
https://github.com/kubernetes-csi/livenessprobe/blob/master/CHANGELOG/CHANGELOG-2.2.md