### PR TITLE
Push aws-ebs-csi-driver to default catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@ orbs:
   architect: giantswarm/architect@2.11.0
 
 workflows:
-  package-and-push-chart-on-tag:
+  version: 2
+  build:
     jobs:
       - architect/push-to-app-catalog:
-          context: "architect"
-          name: "package and push aws-ebs-csi-driver-app chart"
-          app_catalog: "giantswarm-playground-catalog"
-          app_catalog_test: "giantswarm-playground-test-catalog"
+          name: push-to-default-app-catalog
+          app_catalog: "default-catalog"
+          app_catalog_test: "default-test-catalog"
           chart: "aws-ebs-csi-driver-app"
-          # Trigger job on git tag.
           filters:
+            # Trigger the job also on git tag.
             tags:
               only: /^v.*/


### PR DESCRIPTION
For AWS release v15 we need to push this into `default-catalog`. This needs to get rolled out in new clusters.