### PR TITLE
Switch `controller` to daemonset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Run `controller` as daemonset on all nodes.
+
+### Added
+
+- Allow specifying `driverMode` for the `controller` component.
+
 ## [2.10.0] - 2022-04-08
 
 ### Added

--- a/helm/aws-ebs-csi-driver-app/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/helm/aws-ebs-csi-driver-app/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller.yaml
@@ -1,5 +1,5 @@
 # Controller Service
-kind: Deployment
+kind: Daemonset
 apiVersion: apps/v1
 metadata:
   name: ebs-csi-controller
@@ -59,7 +59,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- if ne .Release.Name "kustomize" }}
-            - controller
+            - {{ .Values.controller.driverMode }}
             {{- else }}
             # - {all,controller,node} # specify the driver mode
             {{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller.yaml
@@ -1,5 +1,5 @@
 # Controller Service
-kind: Daemonset
+kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: ebs-csi-controller

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -4,8 +4,6 @@
 
 name: aws-ebs-csi-driver
 
-replicaCount: 1
-
 image:
   repository: docker.io/giantswarm/aws-ebs-csi-driver
   tag: "v1.5.0"

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -108,6 +108,8 @@ region: ""
 
 # Additonal environment variables for the controller
 controller:
+  # can be "controller", "node" or "all".
+  driverMode: controller
   httpEndpoint: "8000"
   extraVars: {}
   logLevel: 2


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/888

We will eventually use the out-of-tree csi driver on AWS management clusters.
The difference with WCs is that master nodes are schedulable and might need EBS volume provisioning and mounting capabilities.
That means we need to make the `controller` component run in all masters and run in `all` mode if needed.

This PR switches the `controller` component from Deployment to Daemonset and allow specifying the driverMode to something else than the previous hardcoded default `controller`.