### PR TITLE
Bump aws-ebs-csi-driver version to `v1.5.1`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Run `controller` as daemonset on all nodes.
+- Run `controller` as daemonset on all master nodes.
+- Bump aws-ebs-csi-driver version to `v1.5.1`.
 
 ### Added
 

--- a/helm/aws-ebs-csi-driver-app/Chart.yaml
+++ b/helm/aws-ebs-csi-driver-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.5.0"
+appVersion: "1.5.1"
 name: aws-ebs-csi-driver-app
 description: A Helm chart for AWS EBS CSI Driver
 version: [[ .Version ]]

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -6,7 +6,7 @@ name: aws-ebs-csi-driver
 
 image:
   repository: docker.io/giantswarm/aws-ebs-csi-driver
-  tag: "v1.5.0"
+  tag: "v1.5.1"
   pullPolicy: IfNotPresent
 
 init:


### PR DESCRIPTION
To address a bunch of CVEs fixed upstream