### PR TITLE
Aws make nodeselector and hostNetwork configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Revert `controller` to be a deployment with 2 replicas by default.
-- Relax `nodeSelector` for both `controller` and `node` in order for `node` to run on all nodes and `controller` to run on any node.
-- Disable `hostNetwork` for `controller` to avoid port conflict.
+- Revert `controller` to be a deployment.
+- Allow specifying `nodeSelector` and `hostNetwork` for `controller` and `node`.
 
 ## [2.11.0] - 2022-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Revert `controller` to be a deployment with 2 replicas by default.
 - Relax `nodeSelector` for both `controller` and `node` in order for `node` to run on all nodes and `controller` to run on any node.
-- Disable `hostNetwork` for both `controller` and `node` to avoid port conflict.
+- Disable `hostNetwork` for `controller` to avoid port conflict.
 
 ## [2.11.0] - 2022-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Revert `controller` to be a deployment with 2 replicas by default.
 - Relax `nodeSelector` for both `controller` and `node` in order for `node` to run on all nodes and `controller` to run on any node.
+- Disable `hostNetwork` for both `controller` and `node` to avoid port conflict.
 
 ## [2.11.0] - 2022-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Revert `controller` to be a deployment with 2 replicas by default.
+- Relax `nodeSelector` for both `controller` and `node` in order for `node` to run on all nodes and `controller` to run on any node.
+
 ## [2.11.0] - 2022-04-11
 
 ### Changed

--- a/helm/aws-ebs-csi-driver-app/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller.yaml
@@ -1,5 +1,5 @@
 # Controller Service
-kind: DaemonSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: ebs-csi-controller
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
+  replicas: {{ .Values.controller.replicas }}
   revisionHistoryLimit: 3
   selector:
     matchLabels:
@@ -23,7 +24,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        kubernetes.io/role: master
+        kubernetes.io/os: linux
         {{- with .Values.nodeSelector }}
 {{ toYaml . | indent 8 }}
         {{- end }}
@@ -58,7 +59,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- if ne .Release.Name "kustomize" }}
-            - {{ .Values.controller.driverMode }}
+            - controller
             {{- else }}
             # - {all,controller,node} # specify the driver mode
             {{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller.yaml
@@ -22,11 +22,13 @@ spec:
       annotations:
         releaseRevision: {{ .Release.Revision | quote }}
     spec:
+      hostNetwork: {{ .Values.controller.hostNetwork }}
+{{- if gt (len (keys .Values.controller.nodeSelector)) 0 }}
       nodeSelector:
-        kubernetes.io/os: linux
-        {{- with .Values.nodeSelector }}
+        {{- with .Values.controller.nodeSelector }}
 {{ toYaml . | indent 8 }}
         {{- end }}
+{{- end }}
       serviceAccountName: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical
       {{- with .Values.affinity }}

--- a/helm/aws-ebs-csi-driver-app/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller.yaml
@@ -22,7 +22,6 @@ spec:
       annotations:
         releaseRevision: {{ .Release.Revision | quote }}
     spec:
-      hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
         {{- with .Values.nodeSelector }}

--- a/helm/aws-ebs-csi-driver-app/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller.yaml
@@ -23,11 +23,13 @@ spec:
         releaseRevision: {{ .Release.Revision | quote }}
     spec:
       hostNetwork: {{ .Values.controller.hostNetwork }}
-{{- if gt (len (keys .Values.controller.nodeSelector)) 0 }}
       nodeSelector:
+{{- if gt (len (keys .Values.controller.nodeSelector)) 0 }}
         {{- with .Values.controller.nodeSelector }}
 {{ toYaml . | indent 8 }}
         {{- end }}
+{{- else }}
+        kubernetes.io/role: master
 {{- end }}
       serviceAccountName: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical

--- a/helm/aws-ebs-csi-driver-app/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller.yaml
@@ -109,6 +109,7 @@ spec:
           ports:
             - name: healthz
               containerPort: 9808
+              hostPort: null
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/helm/aws-ebs-csi-driver-app/templates/node.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/node.yaml
@@ -37,8 +37,7 @@ spec:
         fsGroup: 0
         runAsGroup: 0
         runAsUser: 0
-      hostNetwork: true
-      priorityClassName: {{ .Values.node.priorityClassName | default "system-node-critical" }} 
+      priorityClassName: {{ .Values.node.priorityClassName | default "system-node-critical" }}
       tolerations:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists

--- a/helm/aws-ebs-csi-driver-app/templates/node.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/node.yaml
@@ -18,6 +18,7 @@ spec:
       annotations:
         releaseRevision: {{ .Release.Revision | quote }}
     spec:
+      hostNetwork: {{ .Values.node.hostNetwork }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -27,11 +28,12 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
+{{- if gt (len (keys .Values.controller.nodeSelector)) 0 }}
       nodeSelector:
-        kubernetes.io/os: linux
         {{- with .Values.node.nodeSelector }}
 {{ toYaml . | indent 8 }}
         {{- end }}
+{{- end }}
       serviceAccountName: ebs-csi-node-sa
       securityContext:
         fsGroup: 0

--- a/helm/aws-ebs-csi-driver-app/templates/node.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/node.yaml
@@ -37,6 +37,7 @@ spec:
         fsGroup: 0
         runAsGroup: 0
         runAsUser: 0
+      hostNetwork: true
       priorityClassName: {{ .Values.node.priorityClassName | default "system-node-critical" }}
       tolerations:
         {{- if .Values.node.tolerateAllTaints }}

--- a/helm/aws-ebs-csi-driver-app/templates/node.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/node.yaml
@@ -18,7 +18,6 @@ spec:
       annotations:
         releaseRevision: {{ .Release.Revision | quote }}
     spec:
-      hostNetwork: {{ .Values.node.hostNetwork }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -41,7 +40,7 @@ spec:
         fsGroup: 0
         runAsGroup: 0
         runAsUser: 0
-      hostNetwork: true
+      hostNetwork: {{ .Values.node.hostNetwork }}
       priorityClassName: {{ .Values.node.priorityClassName | default "system-node-critical" }}
       tolerations:
         {{- if .Values.node.tolerateAllTaints }}

--- a/helm/aws-ebs-csi-driver-app/templates/node.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/node.yaml
@@ -28,11 +28,13 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
-{{- if gt (len (keys .Values.controller.nodeSelector)) 0 }}
       nodeSelector:
+{{- if gt (len (keys .Values.controller.nodeSelector)) 0 }}
         {{- with .Values.node.nodeSelector }}
 {{ toYaml . | indent 8 }}
         {{- end }}
+{{- else }}
+        kubernetes.io/role: worker
 {{- end }}
       serviceAccountName: ebs-csi-node-sa
       securityContext:

--- a/helm/aws-ebs-csi-driver-app/templates/node.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/node.yaml
@@ -28,7 +28,7 @@ spec:
                 values:
                 - fargate
       nodeSelector:
-        kubernetes.io/role: worker
+        kubernetes.io/os: linux
         {{- with .Values.node.nodeSelector }}
 {{ toYaml . | indent 8 }}
         {{- end }}

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -106,8 +106,7 @@ region: ""
 # Additonal environment variables for the controller
 controller:
   hostNetwork: true
-  nodeSelector:
-    kubernetes.io/role: master
+  nodeSelector: {}
   replicas: 1
   httpEndpoint: "8000"
   extraVars: {}
@@ -116,8 +115,7 @@ controller:
 node:
   hostNetwork: true
   priorityClassName: ""
-  nodeSelector:
-    kubernetes.io/role: worker
+  nodeSelector: {}
   tolerateAllTaints: true
   tolerations: []
   resources: {}

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -108,7 +108,7 @@ controller:
   hostNetwork: true
   nodeSelector:
     kubernetes.io/role: master
-  replicas: 2
+  replicas: 1
   httpEndpoint: "8000"
   extraVars: {}
   logLevel: 2

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -65,7 +65,6 @@ resources: {}
   #   memory: 128Mi
 
 priorityClassName: ""
-nodeSelector: {}
 tolerateAllTaints: true
 tolerations: []
 affinity: {}
@@ -106,14 +105,19 @@ region: ""
 
 # Additonal environment variables for the controller
 controller:
+  hostNetwork: true
+  nodeSelector:
+    kubernetes.io/role: master
   replicas: 2
   httpEndpoint: "8000"
   extraVars: {}
   logLevel: 2
 
 node:
+  hostNetwork: true
   priorityClassName: ""
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/role: worker
   tolerateAllTaints: true
   tolerations: []
   resources: {}

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -106,8 +106,7 @@ region: ""
 
 # Additonal environment variables for the controller
 controller:
-  # can be "controller", "node" or "all".
-  driverMode: controller
+  replicas: 2
   httpEndpoint: "8000"
   extraVars: {}
   logLevel: 2


### PR DESCRIPTION
On Workload Clusters, this app has to run in hostNetwork otherwise KIAM interferes with it and it does not work.
Problem: the 2 workloads (`node` and `controller`) created by this app both expose the same port (non customizable AFAIK) for health check purposes making the pods unschedulable on the same node.

On WCs we solved the problem by running the `controller` component in the master node(s) only and the `node` component on worker nodes only.

This workaround unfortunately does not work on MCs, because we need the `node` component to be running in all nodes, including masters, otherwise EBS volume mounting does not work.
The good news is that KIAM does not run on MCs, so we don't have the need to run pods in hostNetwork.

This PR adds some new fields in `values.yaml` in order to be able to customize `nodeSelector` and `hostNetwork` for both app workloads setting a default value that is the same as what's always been in WCs (as described above).
This allows us to have a custom values file in MCs and be able to successfully run the app in there as well.

I tested it and it is 100% unobstrusive in WCs.

The only potential risk is that, in theory, we could add custom settings for the app in the WC and, for example, disable hostNetwork for one of the components. But we should be able to catch this problem easily. WDYT?