### PR TITLE
Global registry image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `global.image.registry` as registry domain for all images.
+
 ## [2.14.0] - 2022-06-15
 
 ### Changed

--- a/helm/aws-ebs-csi-driver-app/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller.yaml
@@ -58,7 +58,7 @@ spec:
 {{- end }}
       containers:
         - name: ebs-plugin
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: "{{ .Values.global.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- if ne .Release.Name "kustomize" }}
@@ -127,7 +127,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: csi-provisioner
-          image: {{ printf "%s:%s" .Values.sidecars.provisionerImage.repository .Values.sidecars.provisionerImage.tag }}
+          image: {{ printf "%s/%s:%s" .Values.global.image.registry .Values.sidecars.provisionerImage.repository .Values.sidecars.provisionerImage.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -146,7 +146,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: {{ printf "%s:%s" .Values.sidecars.attacherImage.repository .Values.sidecars.attacherImage.tag }}
+          image: {{ printf "%s/%s:%s" .Values.global.image.registry .Values.sidecars.attacherImage.repository .Values.sidecars.attacherImage.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.controller.logLevel }}
@@ -159,7 +159,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 {{- if .Values.enableVolumeSnapshot }}
         - name: csi-snapshotter
-          image: {{ printf "%s:%s" .Values.sidecars.snapshotterImage.repository .Values.sidecars.snapshotterImage.tag }}
+          image: {{ printf "%s/%s:%s" .Values.global.image.registry .Values.sidecars.snapshotterImage.repository .Values.sidecars.snapshotterImage.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
@@ -171,7 +171,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 {{- end }}
         - name: csi-resizer
-          image: {{ printf "%s:%s" .Values.sidecars.resizerImage.repository .Values.sidecars.resizerImage.tag }}
+          image: {{ printf "%s/%s:%s" .Values.global.image.registry .Values.sidecars.resizerImage.repository .Values.sidecars.resizerImage.tag }}
           imagePullPolicy: Always
           args:
             - --csi-address=$(ADDRESS)
@@ -183,7 +183,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
+          image: {{ printf "%s/%s:%s" .Values.global.image.registry .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/helm/aws-ebs-csi-driver-app/templates/node.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/node.yaml
@@ -57,7 +57,7 @@ spec:
         {{- end }}
       {{- if .Values.enableVolumeLimit }}
       initContainers:
-      - image:  {{ .Values.init.repository }}:{{ .Values.init.tag }}
+      - image:  "{{ .Values.global.image.registry }}/{{ .Values.init.repository }}:{{ .Values.init.tag }}"
         imagePullPolicy: IfNotPresent
         name: ebs-init
         resources:
@@ -81,7 +81,7 @@ spec:
         - name: ebs-plugin
           securityContext:
             privileged: true
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: "{{ .Values.global.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args:
             - node
             - --endpoint=$(CSI_ENDPOINT)
@@ -133,7 +133,7 @@ spec:
           {{- end }}
           {{- end }}
         - name: node-driver-registrar
-          image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
+          image: {{ printf "%s/%s:%s" .Values.global.image.registry .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -153,7 +153,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
+          image: {{ printf "%s/%s:%s" .Values.global.image.registry .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/helm/aws-ebs-csi-driver-app/templates/snapshot-controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/snapshot-controller.yaml
@@ -51,7 +51,7 @@ spec:
         {{- end }}
       containers:
         - name: snapshot-controller
-          image: {{ printf "%s:%s" .Values.snapshotController.repository .Values.snapshotController.tag }}
+          image: {{ printf "%s/%s:%s" .Values.global.image.registry .Values.snapshotController.repository .Values.snapshotController.tag }}
           imagePullPolicy: IfNotPresent
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -5,7 +5,7 @@
 name: aws-ebs-csi-driver
 
 image:
-  repository: docker.io/giantswarm/aws-ebs-csi-driver
+  repository: giantswarm/aws-ebs-csi-driver
   tag: "v1.6.2"
   pullPolicy: IfNotPresent
 
@@ -16,19 +16,19 @@ init:
 
 sidecars:
   provisionerImage:
-    repository: docker.io/giantswarm/csi-provisioner
+    repository: giantswarm/csi-provisioner
     tag: "v3.1.0"
   attacherImage:
-    repository: docker.io/giantswarm/csi-attacher
+    repository: giantswarm/csi-attacher
     tag: "v3.4.0"
   snapshotterImage:
-    repository: docker.io/giantswarm/csi-snapshotter
+    repository: giantswarm/csi-snapshotter
     tag: "v4.2.1"
   livenessProbeImage:
-    repository: docker.io/giantswarm/livenessprobe
+    repository: giantswarm/livenessprobe
     tag: "v2.6.0"
   resizerImage:
-    repository: docker.io/giantswarm/csi-resizer
+    repository: giantswarm/csi-resizer
     tag: "v1.3.0"
   nodeDriverRegistrarImage:
     repository: docker.io/giantswarm/csi-node-driver-registrar

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 init:
-  repository: docker.io/giantswarm/aws-ebs-csi-volume-limiter
+  repository: giantswarm/aws-ebs-csi-volume-limiter
   tag: "0.1.0"
   pullPolicy: IfNotPresent
 
@@ -31,11 +31,11 @@ sidecars:
     repository: giantswarm/csi-resizer
     tag: "v1.3.0"
   nodeDriverRegistrarImage:
-    repository: docker.io/giantswarm/csi-node-driver-registrar
+    repository: giantswarm/csi-node-driver-registrar
     tag: "v2.5.0"
 
 snapshotController:
-  repository: docker.io/giantswarm/snapshot-controller
+  repository: giantswarm/snapshot-controller
   tag: "v4.2.1"
   podLabels: {}
 


### PR DESCRIPTION
Use global.image.registry as registry domain for all images.

This is to allow using alyiun registry in china