### PR TITLE
Fix scraping prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix scraping monitoring port.
+
 ## [2.18.0] - 2022-11-16
 
 ### Changed

--- a/helm/aws-ebs-csi-driver-app/templates/service-controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/service-controller.yaml
@@ -7,9 +7,7 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
     giantswarm.io/monitoring: "true"
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/path: "/metrics"
-    prometheus.io/port: "{{ .Values.controller.httpEndpoint }}"
+    giantswarm.io/monitoring-port: "{{ .Values.controller.httpEndpoint }}"
 spec:
   ports:
   - port: {{ .Values.controller.httpEndpoint }}


### PR DESCRIPTION
We must use giantswarm annotation in order to scrape metrics

Issue: https://github.com/giantswarm/giantswarm/issues/24792