### PR TITLE
Use string type for proxy parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `string` type for the proxy parameters on the `values.schema.json` file.
+
 ## [2.21.0] - 2023-04-03
 
 ### Added

--- a/helm/aws-ebs-csi-driver-app/values.schema.json
+++ b/helm/aws-ebs-csi-driver-app/values.schema.json
@@ -20,13 +20,13 @@
                     "type": "object",
                     "properties": {
                         "http": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "https": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "noProxy": {
-                            "type": "null"
+                            "type": "string"
                         }
                     }
                 }
@@ -170,13 +170,13 @@
             "type": "object",
             "properties": {
                 "http": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "https": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "noProxy": {
-                    "type": "null"
+                    "type": "string"
                 }
             }
         },

--- a/helm/aws-ebs-csi-driver-app/values.schema.json
+++ b/helm/aws-ebs-csi-driver-app/values.schema.json
@@ -20,13 +20,13 @@
                     "type": "object",
                     "properties": {
                         "http": {
-                            "type": "string"
+                            "type": ["null", "string"]
                         },
                         "https": {
-                            "type": "string"
+                            "type": ["null", "string"]
                         },
                         "noProxy": {
-                            "type": "string"
+                            "type": ["null", "string"]
                         }
                     }
                 }
@@ -170,13 +170,13 @@
             "type": "object",
             "properties": {
                 "http": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 },
                 "https": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 },
                 "noProxy": {
-                    "type": "string"
+                    "type": ["null", "string"]
                 }
             }
         },

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -142,16 +142,16 @@ verticalPodAutoscaler:
 
 # set the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variable
 proxy:
-  noProxy:
-  http:
-  https:
+  noProxy: ""
+  http: ""
+  https: ""
 cluster:
   # is getting overwritten by the top level proxy if set
   # These values are generated via cluster-apps-operator
   proxy:
-    noProxy:
-    http:
-    https:
+    noProxy: ""
+    http: ""
+    https: ""
 
 ciliumNetworkPolicy:
   enabled: false

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -142,16 +142,16 @@ verticalPodAutoscaler:
 
 # set the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variable
 proxy:
-  noProxy: ""
-  http: ""
-  https: ""
+  noProxy:
+  http:
+  https:
 cluster:
   # is getting overwritten by the top level proxy if set
   # These values are generated via cluster-apps-operator
   proxy:
-    noProxy: ""
-    http: ""
-    https: ""
+    noProxy:
+    http:
+    https:
 
 ciliumNetworkPolicy:
   enabled: false


### PR DESCRIPTION
When I tried creating a new WC on CAPI, this app wouldn't get installed because
```
status:
  appVersion: ""
  release:
    lastDeployed: null
    reason: |
      values don't meet the specifications of the schema(s) in the following chart(s):
      aws-ebs-csi-driver-app:
      - cluster.proxy.http: Invalid type. Expected: null, given: string
      - cluster.proxy.https: Invalid type. Expected: null, given: string
      - cluster.proxy.noProxy: Invalid type. Expected: null, given: string
    status: not-installed
```