### PR TITLE
Snapshot pdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `snapshot-controller` to 6.2.1.
+- Align `snapthot-controller` deployment to upstream.
+- Add PDB for `snapthot-controller`.
+
 ## [2.21.1] - 2023-04-26
 
 ### Fixed

--- a/helm/aws-ebs-csi-driver-app/templates/snapshot-controller-pdb.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/snapshot-controller-pdb.yaml
@@ -8,7 +8,6 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 spec:
   minAvailable: 1
-  maxUnavailable: 1
   selector:
     matchLabels:
       app: ebs-snapshot-controller

--- a/helm/aws-ebs-csi-driver-app/templates/snapshot-controller-pdb.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/snapshot-controller-pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enableVolumeSnapshot }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -6,6 +7,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
+  minAvailable: 1
   maxUnavailable: 1
   selector:
     matchLabels:
@@ -14,3 +16,4 @@ spec:
       {{- if .Values.snapshotController.podLabels }}
       {{- toYaml .Values.snapshotController.podLabels | nindent 6 }}
       {{- end }}
+{{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/snapshot-controller-pdb.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/snapshot-controller-pdb.yaml
@@ -1,0 +1,16 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ebs-snapshot-controller
+  namespace: kube-system
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: ebs-snapshot-controller
+      {{- include "labels.common" . | nindent 6 }}
+      {{- if .Values.snapshotController.podLabels }}
+      {{- toYaml .Values.snapshotController.podLabels | nindent 6 }}
+      {{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/snapshot-controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/snapshot-controller.yaml
@@ -9,12 +9,19 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 spec:
   revisionHistoryLimit: 3
-  replicas: 1
+  replicas: 2
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
   selector:
     matchLabels:
       app: ebs-snapshot-controller
+  # the snapshot controller won't be marked as ready if the v1 CRDs are unavailable
+  # in #504 the snapshot-controller will exit after around 7.5 seconds if it
+  # can't find the v1 CRDs so this value should be greater than that
+  minReadySeconds: 15
   template:
     metadata:
       annotations:
@@ -58,5 +65,5 @@ spec:
           {{- end }}
           args:
             - --v={{ .Values.controller.logLevel }}
-            - --leader-election=false
+            - --leader-election=true
 {{- end }}

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -36,7 +36,7 @@ sidecars:
 
 snapshotController:
   repository: giantswarm/snapshot-controller
-  tag: "v6.1.0"
+  tag: "v6.2.1"
   podLabels: {}
 
 nameOverride: ""


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26792

Seems to work fine

```
error when evicting pods/"ebs-snapshot-controller-7644bbfc65-mgf4q" -n "kube-system" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```