### PR TITLE
Always install VPA CR if vpa is enabled in the values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Always install the VPA CR if `verticalPodAutoscaler.enabled` is true, no matter if the VPA CRD is present or not.
+
 ## [2.23.0] - 2023-05-30
 
 ### Changed

--- a/helm/aws-ebs-csi-driver-app/templates/controller-vpa.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller-vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" }}
 {{ if .Values.verticalPodAutoscaler.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -31,5 +30,4 @@ spec:
     name:  ebs-csi-controller
   updatePolicy:
     updateMode: Auto
-{{ end }}
 {{ end }}

--- a/helm/aws-ebs-csi-driver-app/templates/node-vpa.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/node-vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" }}
 {{ if .Values.verticalPodAutoscaler.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -25,5 +24,4 @@ spec:
     name:  ebs-csi-node
   updatePolicy:
     updateMode: Auto
-{{ end }}
 {{ end }}

--- a/helm/aws-ebs-csi-driver-app/templates/snapshot-controller-vpa.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/snapshot-controller-vpa.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.enableVolumeSnapshot }}
-{{ if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" }}
 {{ if .Values.verticalPodAutoscaler.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -20,6 +19,5 @@ spec:
     name:  ebs-snapshot-controller
   updatePolicy:
     updateMode: Auto
-{{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
We want to make sure VPA is always installed. With the conditional, there is a race condition when the app platform tries to install this app before installing the VPA CRD app: this app will end up without the VPA and it will never be applied unless the `Chart` is manually recreated.

[We've made this a dependency in our vintage release](https://github.com/giantswarm/releases/pull/1125).