### PR TITLE
remove-gp2-storage-for-eks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a job that removes a gp2 storage class for EKS.
+
 ## [2.27.0] - 2023-10-26
 
 ### Fixed

--- a/helm/aws-ebs-csi-driver-app/Chart.yaml
+++ b/helm/aws-ebs-csi-driver-app/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.21.0"
 name: aws-ebs-csi-driver-app
 description: A Helm chart for AWS EBS CSI Driver
 icon: https://s.giantswarm.io/app-icons/aws/1/dark.svg
-version: 0.1
+version: [[ .Version ]]
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/giantswarm/aws-ebs-csi-driver-app
 sources:

--- a/helm/aws-ebs-csi-driver-app/Chart.yaml
+++ b/helm/aws-ebs-csi-driver-app/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.21.0"
 name: aws-ebs-csi-driver-app
 description: A Helm chart for AWS EBS CSI Driver
 icon: https://s.giantswarm.io/app-icons/aws/1/dark.svg
-version: [[ .Version ]]
+version: 0.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/giantswarm/aws-ebs-csi-driver-app
 sources:

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-cilium-np.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-cilium-np.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.removeStorageClassJob.enabled }}
+{{- if .Values.ciliumNetworkPolicy.enabled }}
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ template "ebs.name" . }}-remove-sc-job
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-7"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+  labels:
+    app.kubernetes.io/component: "{{ template "ebs.name" . }}"remove-sc-job
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: "{{ template "ebs.name" . }}"remove-sc-job
+  egress:
+    - toEntities:
+        - kube-apiserver
+{{- end }}
+{{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-cilium-np.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-cilium-np.yaml
@@ -11,12 +11,12 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
-    app.kubernetes.io/component: "{{ template "ebs.name" . }}"remove-sc-job
+    app.kubernetes.io/component: {{ template "ebs.name" . }}-remove-sc-job
     {{- include "labels.common" . | nindent 4 }}
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/component: "{{ template "ebs.name" . }}"remove-sc-job
+      app.kubernetes.io/component: {{ template "ebs.name" . }}-remove-sc-job
   egress:
     - toEntities:
         - kube-apiserver

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-job.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-job.yaml
@@ -38,7 +38,7 @@ spec:
         - |
           set -o errexit ; set -o xtrace ; set -o nounset
 
-          kubectl delete storageclass {{ .Values.removeStotageClassJob.storageClassName }} --ignore-not-found=true 2>&1
+          kubectl delete storageclass {{ .Values.removeStorageClassJob.storageClassName }} --ignore-not-found=true 2>&1
       restartPolicy: OnFailure
   backoffLimit: 10
 {{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-job.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-job.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.removeStorageClassJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "ebs.name" . }}-remove-sc-job
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+  labels:
+    app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+        {{- include "labels.common" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ template "ebs.name" . }}-remove-sc-job
+      securityContext:
+        runAsUser: {{ .Values.global.securityContext.userID }}
+        runAsGroup: {{ .Values.global.securityContext.groupID }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      containers:
+      - name: kubectl
+        image: "{{ .Values.global.image.registry }}/giantswarm/docker-kubectl:latest"
+        imagePullPolicy: "IfNotPresent"
+        command:
+        - sh
+        - -c
+        - |
+          set -o errexit ; set -o xtrace ; set -o nounset
+
+          kubectl delete storageclass {{ .Values.removeStotageClassJob.storageClassName }} --ignore-not-found=true 2>&1
+      restartPolicy: OnFailure
+  backoffLimit: 10
+{{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-job.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-job.yaml
@@ -10,13 +10,13 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
-    app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+    app.kubernetes.io/component: {{ template "ebs.name" . }}-remove-sc-job
     {{- include "labels.common" . | nindent 4 }}
 spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+        app.kubernetes.io/component: {{ template "ebs.name" . }}-remove-sc-job
         {{- include "labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "ebs.name" . }}-remove-sc-job

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-np.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-np.yaml
@@ -10,12 +10,12 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
-    app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+    app.kubernetes.io/component: {{ template "ebs.name" . }}-remove-sc-job
     {{- include "labels.common" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+      app.kubernetes.io/component: {{ template "ebs.name" . }}-remove-sc-job
   # allow egress traffic to the Kubernetes API
   egress:
   - ports:

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-np.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-np.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.removeStorageClassJob.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "ebs.name" . }}-remove-sc-job
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-7"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+  labels:
+    app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+  # allow egress traffic to the Kubernetes API
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    # legacy port kept for compatibility
+    - port: 6443
+      protocol: TCP
+    to:
+    {{- range tuple "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+  # deny ingress traffic
+  ingress: []
+  policyTypes:
+  - Egress
+  - Ingress
+{{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-rbac.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-rbac.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.removeStorageClassJob.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "ebs.name" . }}-remove-sc-job
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+  labels:
+    app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+    {{- include "labels.common" . | nindent 4 }}
+rules:
+- apiGroups: 
+  - storage.k8s.io
+  resources: 
+  - storageclasses
+  verbs: 
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "ebs.name" . }}-remove-sc-job
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+  labels:
+    app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+    {{- include "labels.common" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "ebs.name" . }}-remove-sc-job
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "ebs.name" . }}-remove-sc-job
+    namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-rbac.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-rbac.yaml
@@ -10,7 +10,7 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
-    app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+    app.kubernetes.io/component: {{ template "ebs.name" . }}-remove-sc-job
     {{- include "labels.common" . | nindent 4 }}
 rules:
 - apiGroups: 
@@ -31,7 +31,7 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
-    app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+    app.kubernetes.io/component: {{ template "ebs.name" . }}-remove-sc-job
     {{- include "labels.common" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-sa.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-sa.yaml
@@ -9,6 +9,6 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
-    app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+    app.kubernetes.io/component: {{ template "ebs.name" . }}-remove-sc-job
     {{- include "labels.common" . | nindent 4 }}
 {{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-sa.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-sa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.removeStorageClassJob.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "ebs.name" . }}-remove-sc-job
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+  labels:
+    app.kubernetes.io/component: "{{ template "ebs.name" . }}"-remove-sc-job
+    {{- include "labels.common" . | nindent 4 }}
+{{- end }}

--- a/helm/aws-ebs-csi-driver-app/values.schema.json
+++ b/helm/aws-ebs-csi-driver-app/values.schema.json
@@ -215,7 +215,7 @@
                 }
             }
         },
-	"removeStotageClassJob": {
+	"removeStorageClassJob": {
             "type": "object",
             "properties": {
 	      "enabled": {

--- a/helm/aws-ebs-csi-driver-app/values.schema.json
+++ b/helm/aws-ebs-csi-driver-app/values.schema.json
@@ -215,6 +215,17 @@
                 }
             }
         },
+	"removeStotageClassJob": {
+            "type": "object",
+            "properties": {
+	      "enabled": {
+		"type": "boolean"
+	      },
+	      "storageClassName": {
+		"type": "string"
+	      }
+	    }
+	},
         "sidecars": {
             "type": "object",
             "properties": {

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -127,6 +127,10 @@ serviceAccount:
   snapshot:
     annotations: {}
 
+removeStotageClassJob:
+  enabled: false
+  storageClassName: gp2
+
 global:
   image:
     registry: docker.io

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -127,7 +127,7 @@ serviceAccount:
   snapshot:
     annotations: {}
 
-removeStotageClassJob:
+removeStorageClassJob:
   enabled: false
   storageClassName: gp2
 


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/28688

EKS deploys by default a storage class named `gp2` which is set to be the default, this app deploys storage class `gp3` which is also set to be the default storage class, this cause problem as PVC cannot be created due 2 default storage classes, Kubernetes throw error in such scenario


 As we don't need the storage class provided by the EKS we can (and need to) remove it 