### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [2.28.0] - 2023-11-03
 
 ### Added

--- a/helm/aws-ebs-csi-driver-app/values.yaml
+++ b/helm/aws-ebs-csi-driver-app/values.yaml
@@ -133,7 +133,7 @@ removeStorageClassJob:
 
 global:
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
   securityContext:
     # global.securityContext.groupID
     groupID: 1000


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
