### PR TITLE
Disable PSPs for CRD job when `podSecurityStandards` are enforced.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Disable PSPs for CRD job when `podSecurityStandards` are enforced. 
+
 ## [2.30.0] - 2024-04-02
 
 ### Removed

--- a/helm/aws-ebs-csi-driver-app/templates/crd-install/crd-psp.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/crd-install/crd-psp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.podSecurityStandards.enforced }}
 {{- if .Values.enableVolumeSnapshot }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -34,4 +35,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/helm/aws-ebs-csi-driver-app/templates/crd-install/crd-rbac.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/crd-install/crd-rbac.yaml
@@ -29,6 +29,7 @@ rules:
   - delete
   - get
   - patch
+{{- if not .Values.global.podSecurityStandards.enforced }}
 - apiGroups:
   - policy
   resources:
@@ -37,6 +38,7 @@ rules:
   - {{ template "ebs.name.crdInstall" . }}
   verbs:
   - use
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Tested, works fine in 1.25