### PR TITLE
Make csi-resizer imagePullPolicy use values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change to use ImagePullPolicy as specified via values.
+
 ## [2.30.1] - 2024-04-11
 
 ### Fixed

--- a/helm/aws-ebs-csi-driver-app/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/controller.yaml
@@ -190,7 +190,7 @@ spec:
 {{- end }}
         - name: csi-resizer
           image: {{ printf "%s/%s:%s" .Values.global.image.registry .Values.sidecars.resizerImage.repository .Values.sidecars.resizerImage.tag }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.controller.logLevel }}

--- a/helm/aws-ebs-csi-driver-app/templates/crd-install/crd-job.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/crd-install/crd-job.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: kubectl
         image: "{{ .Values.global.image.registry }}/giantswarm/docker-kubectl:latest"
-        imagePullPolicy: "IfNotPresent"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - sh
         - -c

--- a/helm/aws-ebs-csi-driver-app/templates/node.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/node.yaml
@@ -58,7 +58,7 @@ spec:
       {{- if .Values.enableVolumeLimit }}
       initContainers:
       - image:  "{{ .Values.global.image.registry }}/{{ .Values.init.repository }}:{{ .Values.init.tag }}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: ebs-init
         resources:
           limits:

--- a/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-job.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/remove-storage-class/remove-storage-class-job.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: kubectl
         image: "{{ .Values.global.image.registry }}/giantswarm/docker-kubectl:latest"
-        imagePullPolicy: "IfNotPresent"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - sh
         - -c

--- a/helm/aws-ebs-csi-driver-app/templates/snapshot-controller.yaml
+++ b/helm/aws-ebs-csi-driver-app/templates/snapshot-controller.yaml
@@ -59,7 +59,7 @@ spec:
       containers:
         - name: snapshot-controller
           image: {{ printf "%s/%s:%s" .Values.global.image.registry .Values.snapshotController.repository .Values.snapshotController.tag }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
While checking out increased network traffic, found this image using ImagePullPolicy Always, which is unnecessary as it's tagged, so fix to use the template value properly.