### PR TITLE
Use `ignorePaths` from renovate base config since those aren't merged, exclude repo-specific file using `packageRules` instead

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,11 @@
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
   ],
-  "ignorePaths": [
-      "helm/aws-ebs-csi-driver-app/values.yaml"
+  // Take `ignorePaths` from preset but override for repo-specific files
+  "packageRules": [
+    {
+      "matchFileNames": ["helm/aws-ebs-csi-driver-app/values.yaml"],
+      "enabled": false,
+    },
   ],
 }


### PR DESCRIPTION
We currently get unwanted PRs like [this one](https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/328).