### PR TITLE
Add IRSA configuration to EBS CSI controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add IRSA environment variables (`AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`), projected ServiceAccountToken volume, and `AWS_REGION` to the EBS CSI controller, enabling IRSA authentication in CAPA clusters.
+
 ## [4.2.0] - 2026-03-25
 
 ### Breaking

--- a/helm/aws-ebs-csi-driver-bundle/templates/_helpers.tpl
+++ b/helm/aws-ebs-csi-driver-bundle/templates/_helpers.tpl
@@ -104,7 +104,33 @@ Set Giant Swarm specific values — computes IRSA role ARN.
 {{- define "giantswarm.setValues" -}}
 {{- $cmvalues := (include "aws-ebs-csi-driver-bundle.crossplaneConfigData" .) | fromYaml -}}
 {{- $clusterID := (include "aws-ebs-csi-driver-bundle.clusterID" .) -}}
-{{- $_ := set .Values.controller.serviceAccount.annotations "eks.amazonaws.com/role-arn" (printf "arn:%s:iam::%s:role/%s-ebs-csi-driver" $cmvalues.awsPartition $cmvalues.accountID $clusterID) -}}
+{{- $roleArn := printf "arn:%s:iam::%s:role/%s-ebs-csi-driver" $cmvalues.awsPartition $cmvalues.accountID $clusterID -}}
+{{- $audience := "sts.amazonaws.com" -}}
+{{- if eq $cmvalues.awsPartition "aws-cn" -}}
+{{- $audience = "sts.amazonaws.com.cn" -}}
+{{- end -}}
+{{/* ServiceAccount annotation */}}
+{{- $_ := set .Values.controller.serviceAccount.annotations "eks.amazonaws.com/role-arn" $roleArn -}}
+{{/* AWS region — the inner chart renders this as the AWS_REGION env var */}}
+{{- $_ := set .Values.controller "region" $cmvalues.region -}}
+{{/* IRSA env vars */}}
+{{- $irsaEnv := list
+  (dict "name" "AWS_ROLE_ARN" "value" $roleArn)
+  (dict "name" "AWS_WEB_IDENTITY_TOKEN_FILE" "value" "/var/run/secrets/eks.amazonaws.com/serviceaccount/token")
+-}}
+{{- $_ := set .Values.controller "env" (concat $irsaEnv (default list .Values.controller.env)) -}}
+{{/* Projected ServiceAccountToken volume */}}
+{{- $irsaVolume := list
+  (dict "name" "aws-iam-token" "projected" (dict "sources" (list
+    (dict "serviceAccountToken" (dict "audience" $audience "expirationSeconds" 86400 "path" "token"))
+  )))
+-}}
+{{- $_ := set .Values.controller "volumes" (concat $irsaVolume (default list .Values.controller.volumes)) -}}
+{{/* Volume mount for the projected token */}}
+{{- $irsaVolumeMount := list
+  (dict "name" "aws-iam-token" "mountPath" "/var/run/secrets/eks.amazonaws.com/serviceaccount/" "readOnly" true)
+-}}
+{{- $_ := set .Values.controller "volumeMounts" (concat $irsaVolumeMount (default list .Values.controller.volumeMounts)) -}}
 {{- if and (not .Values.clusterName) -}}
 {{- $_ := set .Values "clusterName" $clusterID -}}
 {{- end -}}


### PR DESCRIPTION
Currently, `aws-ebs-csi-driver` depends on the `aws-pod-identity-webhook` to inject the right env vars, and mount the service account token. This creates an implicit dependency. By manually configuring these things, we remove that dependency.

## Summary

- Extend `giantswarm.setValues` in the bundle chart to inject IRSA configuration into the EBS CSI controller:
  - `controller.region` — sets `AWS_REGION` env var (already supported by the inner chart)
  - `controller.env` — adds `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`
  - `controller.volumes` — adds a projected `serviceAccountToken` volume with OIDC audience
  - `controller.volumeMounts` — mounts the token at `/var/run/secrets/eks.amazonaws.com/serviceaccount/`
- All values are derived from the `{clusterID}-crossplane-config` ConfigMap (region, awsPartition, accountID)
- No changes needed to the inner chart or to `cluster-aws`
- Supports China regions (`aws-cn` partition) with `sts.amazonaws.com.cn` audience

## Test plan

- [ ] Run `helm template` on the bundle chart with a mock crossplane-config ConfigMap and verify the rendered ConfigMap values include the IRSA env vars, projected volume, and volume mount
- [ ] Deploy to a test CAPA cluster and verify the EBS CSI controller pods have the IRSA token mounted and can create/attach EBS volumes
- [ ] Verify existing clusters without IRSA continue to work (backward compatible via `concat` with existing empty arrays)