### PR TITLE
Fix VPA updateMode for ebs-csi-node DaemonSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add IRSA environment variables (`AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`), projected ServiceAccountToken volume, and `AWS_REGION` to the EBS CSI controller, enabling IRSA authentication in CAPA clusters.
 
+### Fixed
+
+- Fix VPA `updateMode` for `ebs-csi-node` DaemonSet from `Auto` to `Initial`. VPA cannot evict DaemonSet pods, so `Auto` mode silently produces recommendations without ever applying them. `Initial` correctly sets resources at pod creation time.
+
 ## [4.2.0] - 2026-03-25
 
 ### Breaking

--- a/helm/aws-ebs-csi-driver/templates/vpa.yaml
+++ b/helm/aws-ebs-csi-driver/templates/vpa.yaml
@@ -35,5 +35,5 @@ spec:
     kind: DaemonSet
     name: ebs-csi-node
   updatePolicy:
-    updateMode: Auto
+    updateMode: Initial
 {{- end }}


### PR DESCRIPTION
## What

Changes the VPA `updateMode` for the `ebs-csi-node` DaemonSet from `Auto` to `Initial`.

## Why

VPA does **not** support `Auto` mode for DaemonSets. The VPA admission controller can set initial resource requests when a pod is first created (`Initial` mode), but VPA cannot evict DaemonSet pods to apply updated recommendations — DaemonSet pods are not managed by a replication controller that VPA can trigger restarts through.

With `updateMode: Auto` on a DaemonSet, VPA silently produces recommendations but never applies them, giving a false sense of active right-sizing. Switching to `Initial` makes the behaviour explicit and correct: resources are set at pod creation time (e.g. after a node rolls or the DaemonSet is redeployed), and recommendations remain visible for manual review or future action.

The `ebs-csi-controller` Deployment is unaffected — `Auto` mode is correct there.

## References

- giantswarm/giantswarm#35769 
- [VPA DaemonSet limitations](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#known-limitations)