### PR TITLE
Re-enable metrics, force use of `ServiceMonitor` to avoid rendering without them if CRDs are not installed yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bring back metrics port for controller
+- Re-enable metrics, force use of `ServiceMonitor` to avoid rendering without them if CRDs are not installed yet
 
 ## [4.2.0] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add IRSA environment variables (`AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`), projected ServiceAccountToken volume, and `AWS_REGION` to the EBS CSI controller, enabling IRSA authentication in CAPA clusters.
 
+### Fixed
+
+- Bring back metrics port for controller
+
 ## [4.2.0] - 2026-03-25
 
 ### Breaking

--- a/helm/aws-ebs-csi-driver/values.yaml
+++ b/helm/aws-ebs-csi-driver/values.yaml
@@ -188,6 +188,7 @@ upstream:
     enableMetrics: true
     enablePrometheusAnnotations: false
     serviceMonitor:
+      forceEnable: true
       labels:
         release: prometheus
     resources:

--- a/helm/aws-ebs-csi-driver/values.yaml
+++ b/helm/aws-ebs-csi-driver/values.yaml
@@ -185,6 +185,7 @@ upstream:
 
   # GS overrides for controller
   controller:
+    enableMetrics: true
     enablePrometheusAnnotations: false
     serviceMonitor:
       labels:


### PR DESCRIPTION
Found in https://github.com/giantswarm/giantswarm/issues/36119

We previously had the metrics port defined ourselves, but since the upstream chart supports `ServiceMonitor`, we can use that instead of https://github.com/giantswarm/aws-ebs-csi-driver-servicemonitors-app. Upstream defaults to `lookup` is `ServiceMonitor` is available. Since we have dependency management, I'd rather enforce using the CR (which is a separate toggle).