### PR TITLE
Propagate proxy values to upstream chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add IRSA environment variables (`AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`), projected ServiceAccountToken volume, and `AWS_REGION` to the EBS CSI controller, enabling IRSA authentication in CAPA clusters.
+- Propagate proxy values from the bundle (`proxy.http`, `proxy.noProxy`) to the upstream chart (`proxy.http_proxy`, `proxy.no_proxy`) when set.
 
 ## [4.2.0] - 2026-03-25
 

--- a/helm/aws-ebs-csi-driver-bundle/.abs/main.yaml
+++ b/helm/aws-ebs-csi-driver-bundle/.abs/main.yaml
@@ -1,6 +1,5 @@
-chart-dir: helm/aws-ebs-csi-driver
+chart-dir: ./
 replace-chart-version-with-git: true
 replace-app-version-with-git: true
 generate-metadata: true
 catalog-base-url: https://giantswarm.github.io/default-catalog/
-ct-config: ./.circleci/ct-config.yaml

--- a/helm/aws-ebs-csi-driver-bundle/.abs/main.yaml
+++ b/helm/aws-ebs-csi-driver-bundle/.abs/main.yaml
@@ -1,4 +1,4 @@
-chart-dir: ./
+chart-dir: helm/aws-ebs-csi-driver-bundle
 replace-chart-version-with-git: true
 replace-app-version-with-git: true
 generate-metadata: true

--- a/helm/aws-ebs-csi-driver-bundle/Chart.yaml
+++ b/helm/aws-ebs-csi-driver-bundle/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-ebs-csi-driver-bundle
 description: A Helm chart for AWS EBS CSI Driver with IAM resources
-version: ""
-appVersion: 1.56.0
+version: "4.2.0"
+appVersion: "4.2.0"
 home: https://github.com/giantswarm/aws-ebs-csi-driver-app
 icon: https://s.giantswarm.io/app-icons/aws/2/dark.svg
 kubeVersion: ">=1.17.0-0"

--- a/helm/aws-ebs-csi-driver-bundle/templates/_helpers.tpl
+++ b/helm/aws-ebs-csi-driver-bundle/templates/_helpers.tpl
@@ -181,7 +181,7 @@ Any other key in .Values passes through to upstream automatically.
 {{/* Keys forwarded as workload extras (not under upstream:) */}}
 {{- $extrasKeys := list "networkPolicy" "verticalPodAutoscaler" "global" -}}
 {{/* Keys with special handling */}}
-{{- $specialKeys := list "image" "sidecars" "controller" "node" "storageClasses" "extraVolumeTags" -}}
+{{- $specialKeys := list "image" "sidecars" "controller" "node" "storageClasses" "extraVolumeTags" "proxy" -}}
 {{- $reservedKeys := concat $bundleOnlyKeys $extrasKeys $specialKeys -}}
 
 {{/* Image: combine GS split format; set containerRegistry to empty since
@@ -206,6 +206,22 @@ Any other key in .Values passes through to upstream automatically.
 {{/* storageClasses: forwarded to upstream */}}
 {{- if .Values.storageClasses -}}
 {{- $_ := set $upstreamValues "storageClasses" .Values.storageClasses -}}
+{{- end -}}
+
+{{/* Proxy: translate bundle keys (http, noProxy) into the keys the upstream
+     chart expects (http_proxy, no_proxy). Only forwarded when set, so the
+     upstream's empty defaults remain in effect otherwise. */}}
+{{- if .Values.proxy -}}
+  {{- $upstreamProxy := dict -}}
+  {{- if .Values.proxy.http -}}
+    {{- $_ := set $upstreamProxy "http_proxy" .Values.proxy.http -}}
+  {{- end -}}
+  {{- if .Values.proxy.noProxy -}}
+    {{- $_ := set $upstreamProxy "no_proxy" .Values.proxy.noProxy -}}
+  {{- end -}}
+  {{- if $upstreamProxy -}}
+    {{- $_ := set $upstreamValues "proxy" $upstreamProxy -}}
+  {{- end -}}
 {{- end -}}
 
 {{/* Preserve the original chart name so selectors stay compatible with pre-dependency upgrades */}}

--- a/helm/aws-ebs-csi-driver/.abs/main.yaml
+++ b/helm/aws-ebs-csi-driver/.abs/main.yaml
@@ -1,5 +1,6 @@
-chart-dir: ./
+chart-dir: helm/aws-ebs-csi-driver
 replace-chart-version-with-git: true
 replace-app-version-with-git: false
 generate-metadata: true
 catalog-base-url: https://giantswarm.github.io/default-catalog/
+ct-config: ./.circleci/ct-config.yaml

--- a/helm/aws-ebs-csi-driver/.abs/main.yaml
+++ b/helm/aws-ebs-csi-driver/.abs/main.yaml
@@ -1,0 +1,5 @@
+chart-dir: ./
+replace-chart-version-with-git: true
+replace-app-version-with-git: false
+generate-metadata: true
+catalog-base-url: https://giantswarm.github.io/default-catalog/

--- a/helm/aws-ebs-csi-driver/Chart.yaml
+++ b/helm/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aws-ebs-csi-driver
 description: A Helm chart for the AWS EBS CSI Driver.
 version: 4.2.0
-appVersion: 4.2.0
+appVersion: "2.56.1"
 home: https://github.com/giantswarm/aws-ebs-csi-driver-app
 icon: https://s.giantswarm.io/app-icons/aws/2/dark.svg
 annotations:

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,4 +14,19 @@
       "enabled": false,
     },
   ],
+  "customManagers": [
+    {
+      // Keep `appVersion` in helm/aws-ebs-csi-driver/Chart.yaml in sync with
+      // the upstream aws-ebs-csi-driver chart dependency version
+      "customType": "regex",
+      "managerFilePatterns": ["/^helm/aws-ebs-csi-driver/Chart\\.yaml$/"],
+      "matchStrings": [
+        "appVersion:\\s*\"?(?<currentValue>[^\"\\s]+)\"?",
+      ],
+      "depNameTemplate": "aws-ebs-csi-driver",
+      "packageNameTemplate": "aws-ebs-csi-driver",
+      "datasourceTemplate": "helm",
+      "registryUrlTemplate": "https://kubernetes-sigs.github.io/aws-ebs-csi-driver",
+    },
+  ],
 }

--- a/tests/e2e/config.yaml
+++ b/tests/e2e/config.yaml
@@ -1,4 +1,4 @@
-appName: "aws-ebs-csi-driver-bundle"
+appName: "aws-ebs-csi-driver"
 repoName: "aws-ebs-csi-driver-app"
 appCatalog: "default"
 

--- a/tests/e2e/suites/basic/config.yaml
+++ b/tests/e2e/suites/basic/config.yaml
@@ -1,4 +1,4 @@
-appName: "aws-ebs-csi-driver-bundle"
+appName: "aws-ebs-csi-driver" # Needs to match the name in the release
 repoName: "aws-ebs-csi-driver-app"
 appCatalog: "default"
 

--- a/tests/e2e/suites/basic/values.yaml
+++ b/tests/e2e/suites/basic/values.yaml
@@ -1,1 +1,2 @@
 # Default values - bundle defaults should work
+configmap: {}


### PR DESCRIPTION
- Propagate proxy values to upstream chart
- Fix chart and appVersion configuration for bundle and subchart
- Make renovate track upstream version in `appVersion` field

Towards https://github.com/giantswarm/giantswarm/issues/36465